### PR TITLE
Fix possible timer leaks.

### DIFF
--- a/utils/trylock.go
+++ b/utils/trylock.go
@@ -41,10 +41,12 @@ func (m *Mutex) TryLock(timeout time.Duration) bool {
 	case m.c <- struct{}{}:
 		return true
 	default:
+		timer := time.NewTimer(timeout)
 		select {
 		case m.c <- struct{}{}:
+			timer.Stop()
 			return true
-		case <-time.After(timeout):
+		case <-timer.C:
 			return false
 		}
 


### PR DESCRIPTION
trylock使用time.After(timeout)可能会导致timer对象泄漏，列如某个时候trylock在timeout时间内获取到锁了，则之前设置的time.After(timeout)还是要做timeout时间后触发。考虑到性能问题，切换到NewTimer，当获取到锁后就立刻stop掉timer，规避timer堆积。

![image](https://user-images.githubusercontent.com/8215757/74127034-6b365080-4c14-11ea-83af-31f96c0f726c.png)