### PR TITLE
Add expire_map structure with expiration control.

### DIFF
--- a/utils/expire_map.go
+++ b/utils/expire_map.go
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import (
+	"sync"
+	"time"
+)
+
+const NeverExpire time.Duration = -1
+
+type expiredata struct {
+	data        interface{}
+	expiredTime time.Time
+	valid       time.Duration
+}
+
+func (d *expiredata) checkValid() bool {
+	// if valid is equal NeverExpire and don't need to update.
+	if d.valid == NeverExpire {
+		return true
+	}
+
+	return d.expiredTime.After(time.Now())
+}
+
+type ExpiredMap struct {
+	syncMap *sync.Map
+	syncMod bool // true means using synchronous update mode, otherwise async mod
+
+	// When the cache expires, it is used to update the cache.
+	UpdateHandler func(interface{}) (interface{}, bool)
+}
+
+// handler is used to update the data if the cache is invalid during Get.
+// syncMod is set true means that the handler is called synchronously, and the others are asynchronous.
+func NewExpiredMap(handler func(interface{}) (interface{}, bool), syncMod bool) *ExpiredMap {
+	return &ExpiredMap{
+		syncMap:       &sync.Map{},
+		UpdateHandler: handler,
+		syncMod:       syncMod,
+	}
+}
+
+// Set a key and val with an expiration time.
+// key and val represent cached index and user data.
+// valid is used to set the expire time of the cache. For example, if valid=10 means the data expires after 10 Duration.
+func (e *ExpiredMap) Set(key, val interface{}, valid time.Duration) {
+	ct := time.Now()
+	e.syncMap.Store(key, expiredata{data: val, expiredTime: ct.Add(valid), valid: valid})
+}
+
+// Get the cache indexed by key.
+// If the cache is hit, the bool value indicates whether the cache is expired.
+func (e *ExpiredMap) Get(key interface{}) (interface{}, bool) {
+	if val, ok := e.syncMap.Load(key); ok {
+		eval := val.(expiredata)
+		if ok := eval.checkValid(); ok {
+			return eval.data, ok
+		}
+
+		// Cache expires, updated via updateHandler.
+		if e.UpdateHandler != nil {
+			e.updateData(key, eval.valid)
+			// If it is a synchronous update mode, get data again.
+			if e.syncMod {
+				if val, ok := e.syncMap.Load(key); ok {
+					eval := val.(expiredata)
+					if ok := eval.checkValid(); ok {
+						return eval.data, ok
+					}
+				}
+			}
+		}
+
+		return eval.data, false
+	}
+
+	// When the cache is not hit, not update actively update.
+	return nil, false
+}
+
+func (e *ExpiredMap) updateData(key interface{}, valid time.Duration) {
+	updater := func() {
+		if newVal, ok := e.UpdateHandler(key); ok {
+			ct := time.Now()
+			e.syncMap.Store(key, expiredata{data: newVal, expiredTime: ct.Add(valid), valid: valid})
+		}
+	}
+
+	if e.syncMod {
+		updater()
+
+	} else {
+		GoWithRecover(updater, nil)
+	}
+
+}

--- a/utils/expire_map_test.go
+++ b/utils/expire_map_test.go
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import (
+	"testing"
+	"time"
+)
+
+func TestExpiredMap(t *testing.T) {
+	handler := func(key interface{}) (interface{}, bool) {
+		return "val2", true
+	}
+
+	// Test sync update mod
+	expireMap := NewExpiredMap(handler, true)
+
+	val, ok := expireMap.Get("nokey")
+	if ok {
+		t.Error("want get nil, but got ok")
+	}
+
+	expireMap.Set("key1", "val1", time.Duration(2)*time.Millisecond)
+	val, ok = expireMap.Get("key1")
+	if val != "val1" || !ok {
+		t.Errorf("want get val %s, but got val %s", "val1", val)
+	}
+
+	// If it expires, it should be automatically updated
+	time.Sleep(time.Millisecond * 3)
+	val, ok = expireMap.Get("key1")
+	if val != "val2" || !ok {
+		t.Errorf("want get val %s, but got val %s", "val2", val)
+	}
+
+	// Check sync mode and update the slow scene
+	handlerSlow := func(key interface{}) (interface{}, bool) {
+		time.Sleep(time.Millisecond * 3)
+		return "val3", true
+	}
+
+	expireMap.UpdateHandler = handlerSlow
+
+	time.Sleep(time.Millisecond * 3)
+	val, ok = expireMap.Get("key1")
+	if val != "val3" || !ok {
+		t.Errorf("want get val %s, but got val %s", "val3", val)
+	}
+
+	// Test async update mod
+	asyncHandler := func(key interface{}) (interface{}, bool) {
+		time.Sleep(time.Millisecond * 1)
+		return "val5", true
+	}
+
+	expireMap = NewExpiredMap(asyncHandler, false)
+
+	expireMap.Set("key1", "val4", time.Duration(2)*time.Millisecond)
+	val, ok = expireMap.Get("key1")
+	if val != "val4" || !ok {
+		t.Errorf("want get val %s, but got val %s", "val4", val)
+	}
+
+	time.Sleep(time.Millisecond * 3)
+	val, ok = expireMap.Get("key1")
+	if val != "val4" || ok {
+		t.Errorf("async mod want get val %s, but got val %s", "val4", val)
+	}
+
+	time.Sleep(time.Millisecond * 2)
+	val, ok = expireMap.Get("key1")
+	if val != "val5" || !ok {
+		t.Errorf("async mod want get val %s, but got val %s", "val5", val)
+	}
+
+	// Test NeverExpire
+
+	expireMap = NewExpiredMap(nil, false)
+	expireMap.Set("key1", "val6", NeverExpire)
+	time.Sleep(time.Second * 1)
+	val, ok = expireMap.Get("key1")
+	if !ok {
+		t.Error("want never expire, but got expired")
+	}
+
+}
+
+func BenchmarkExpiredMapSync(b *testing.B) {
+	handler := func(key interface{}) (interface{}, bool) {
+		return "val2", true
+	}
+
+	// Test sync update mod
+	expireMap := NewExpiredMap(handler, true)
+
+	for i := 0; i < b.N; i++ {
+		expireMap.Set("key", i, time.Duration(10))
+		expireMap.Get("key")
+	}
+}
+
+func BenchmarkExpiredMapAsync(b *testing.B) {
+	handler := func(key interface{}) (interface{}, bool) {
+		return "val2", true
+	}
+
+	// Test async update mod
+	expireMap := NewExpiredMap(handler, false)
+
+	for i := 0; i < b.N; i++ {
+		expireMap.Set("key", i, time.Duration(10))
+		expireMap.Get("key")
+	}
+}
+
+func BenchmarkExpiredMapAsyncParallel(b *testing.B) {
+	handler := func(key interface{}) (interface{}, bool) {
+		return "val2", true
+	}
+
+	// Test async update mod
+	expireMap := NewExpiredMap(handler, false)
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			expireMap.Set("key", 1, time.Duration(10))
+			expireMap.Get("key")
+		}
+	})
+
+}
+
+func BenchmarkExpiredMapSyncParallel(b *testing.B) {
+	handler := func(key interface{}) (interface{}, bool) {
+		return "val2", true
+	}
+
+	// Test sync update mod
+	expireMap := NewExpiredMap(handler, true)
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			expireMap.Set("key", 1, time.Duration(10))
+			expireMap.Get("key")
+		}
+	})
+
+}


### PR DESCRIPTION
Design a general `ExpiredMap` with expiration time, and provide NewExpiredMap, Get, Set methods.

• NewExpiredMap(handler func(interface{}) (interface{}, bool), syncMod bool) *ExpiredMap

This function has two parameters. The first parameter is a function pointer to the method to update the cache. The second parameter is to set the cache update in synchronous or asynchronous mode. if `SyncMod=true` represents the synchronous mode.

• Set(key, val interface{}, valid time.Duration)

The Set method is used to Set the cache data. The first parameter is the key to Set the cache index, the second parameter is the user data, and the third parameter is to Set the expiration time of the cache. For example, valid=10 means that the cache expires after 10s.

• Get(key interface{}) (val interface{}, expired bool)

Get the cache of the by key. If the cache expires, it will be updated with the handler set at the initialization of ExpiredMap (the update mode supports synchronous and asynchronous modes, and the default is asynchronous mode), `val` is the user data of the corresponding key, and expired means whether the data is expired.
