### PR TITLE
fix #15 

### DIFF
--- a/log/logger.go
+++ b/log/logger.go
@@ -433,11 +433,6 @@ func (l *Logger) Close() error {
 	return nil
 }
 
-func (l *Logger) CloseRotate() error {
-	close(l.stopRotate)
-	return nil
-}
-
 func (l *Logger) Reopen() error {
 	defer func() {
 		if r := recover(); r != nil {

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -101,7 +101,7 @@ func TestLogDefaultRollerTime(t *testing.T) {
 	defer func() {
 		doRotate = doRotateFunc
 	}()
-	logger, err := GetOrCreateLogger(logName, &Roller{MaxTime: 10})
+	logger, err := GetOrCreateLogger(logName, &Roller{MaxTime: 10, Rotation: afterRotation})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -141,7 +141,7 @@ func TestLogDefaultRollerAfterDelete(t *testing.T) {
 		doRotate = doRotateFunc
 	}()
 
-	logger, err := GetOrCreateLogger(logName, &Roller{MaxTime: 10})
+	logger, err := GetOrCreateLogger(logName, &Roller{MaxTime: 10, Rotation: afterRotation})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -255,7 +255,7 @@ func TestRotateInteval(t *testing.T) {
 	t2 := time.Date(year, month, day, now.Hour(), 05, 8, 0, time.Local)
 	lg2 := &Logger{
 		create: t2,
-		roller: &Roller{MaxTime: 3600},
+		roller: &Roller{MaxTime: 3600, Rotation: afterRotation},
 	}
 	lg2.startRotate()
 	time.Sleep(10 * time.Millisecond)
@@ -321,7 +321,7 @@ func TestRotateRightNow(t *testing.T) {
 	lg2 := &Logger{
 		output: logfile,
 		create: ct2,
-		roller: &Roller{MaxTime: 3600},
+		roller: &Roller{MaxTime: 3600, Rotation: afterRotation},
 	}
 	lg2.startRotate()
 	time.Sleep(10 * time.Millisecond)

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -101,7 +101,7 @@ func TestLogDefaultRollerTime(t *testing.T) {
 	defer func() {
 		doRotate = doRotateFunc
 	}()
-	logger, err := GetOrCreateLogger(logName, &Roller{MaxTime: 10, Rotation: afterRotation})
+	logger, err := GetOrCreateLogger(logName, &Roller{MaxTime: 10, Handler: rollerHandler})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -141,7 +141,7 @@ func TestLogDefaultRollerAfterDelete(t *testing.T) {
 		doRotate = doRotateFunc
 	}()
 
-	logger, err := GetOrCreateLogger(logName, &Roller{MaxTime: 10, Rotation: afterRotation})
+	logger, err := GetOrCreateLogger(logName, &Roller{MaxTime: 10, Handler: rollerHandler})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -255,7 +255,7 @@ func TestRotateInteval(t *testing.T) {
 	t2 := time.Date(year, month, day, now.Hour(), 05, 8, 0, time.Local)
 	lg2 := &Logger{
 		create: t2,
-		roller: &Roller{MaxTime: 3600, Rotation: afterRotation},
+		roller: &Roller{MaxTime: 3600, Handler: rollerHandler},
 	}
 	lg2.startRotate()
 	time.Sleep(10 * time.Millisecond)
@@ -321,7 +321,7 @@ func TestRotateRightNow(t *testing.T) {
 	lg2 := &Logger{
 		output: logfile,
 		create: ct2,
-		roller: &Roller{MaxTime: 3600, Rotation: afterRotation},
+		roller: &Roller{MaxTime: 3600, Handler: rollerHandler},
 	}
 	lg2.startRotate()
 	time.Sleep(10 * time.Millisecond)

--- a/log/roller.go
+++ b/log/roller.go
@@ -20,6 +20,7 @@ package log
 import (
 	"errors"
 	"io"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -29,7 +30,7 @@ import (
 
 var (
 	// defaultRoller is roller by one day
-	defaultRoller = Roller{MaxTime: defaultRotateTime, Rotation: afterRotation}
+	defaultRoller = Roller{MaxTime: defaultRotateTime, Handler: rollerHandler}
 
 	// lumberjacks maps log filenames to the logger
 	// that is being used to keep them rolled/maintained.
@@ -66,9 +67,11 @@ type Roller struct {
 	Compress   bool
 	LocalTime  bool
 	// roller rotate time, if the MAxTime is configured, ignore the others config
-	MaxTime  int64
-	Rotation AfterRotation
+	MaxTime int64
+	Handler RollerHandler
 }
+
+type RollerHandler func(l *LoggerInfo)
 
 // GetLogWriter returns an io.Writer that writes to a rolling logger.
 // This should be called only from the main goroutine (like during
@@ -117,7 +120,16 @@ func DefaultRoller() *Roller {
 		MaxBackups: defaultRotateKeep,
 		Compress:   false,
 		LocalTime:  true,
-		Rotation:   afterRotation,
+		Handler:    rollerHandler,
+	}
+}
+
+func rollerHandler(l *LoggerInfo) {
+	// ignore the rename error, in case the l.output is deleted
+	if l.LogRoller.MaxTime == defaultRotateTime {
+		os.Rename(l.FileName, l.FileName+"."+l.CreateTime.Format("2006-01-02"))
+	} else {
+		os.Rename(l.FileName, l.FileName+"."+l.CreateTime.Format("2006-01-02_15"))
 	}
 }
 

--- a/log/roller.go
+++ b/log/roller.go
@@ -29,7 +29,7 @@ import (
 
 var (
 	// defaultRoller is roller by one day
-	defaultRoller = Roller{MaxTime: defaultRotateTime}
+	defaultRoller = Roller{MaxTime: defaultRotateTime, Rotation: afterRotation}
 
 	// lumberjacks maps log filenames to the logger
 	// that is being used to keep them rolled/maintained.
@@ -66,7 +66,8 @@ type Roller struct {
 	Compress   bool
 	LocalTime  bool
 	// roller rotate time, if the MAxTime is configured, ignore the others config
-	MaxTime int64
+	MaxTime  int64
+	Rotation AfterRotation
 }
 
 // GetLogWriter returns an io.Writer that writes to a rolling logger.
@@ -116,6 +117,7 @@ func DefaultRoller() *Roller {
 		MaxBackups: defaultRotateKeep,
 		Compress:   false,
 		LocalTime:  true,
+		Rotation:   afterRotation,
 	}
 }
 

--- a/log/roller_test.go
+++ b/log/roller_test.go
@@ -24,7 +24,7 @@ import (
 func TestParseRoller(t *testing.T) {
 	defer func() {
 		// reset
-		defaultRoller = Roller{MaxTime: defaultRotateTime, Rotation: afterRotation}
+		defaultRoller = Roller{MaxTime: defaultRotateTime, Handler: rollerHandler}
 	}()
 	errorPraseArgs := "size=100 age=10 keep=10 compress=1"
 	roller, err := ParseRoller(errorPraseArgs)
@@ -109,7 +109,7 @@ func TestInitDefaultRoller(t *testing.T) {
 	InitGlobalRoller("time=1")
 	defer func() {
 		// reset
-		defaultRoller = Roller{MaxTime: defaultRotateTime, Rotation: afterRotation}
+		defaultRoller = Roller{MaxTime: defaultRotateTime, Handler: rollerHandler}
 	}()
 	if lg.roller.MaxTime != 60*60 {
 		t.Errorf("expected roller reset, but not, got: %d", lg.roller.MaxTime)

--- a/log/roller_test.go
+++ b/log/roller_test.go
@@ -24,7 +24,7 @@ import (
 func TestParseRoller(t *testing.T) {
 	defer func() {
 		// reset
-		defaultRoller = Roller{MaxTime: defaultRotateTime}
+		defaultRoller = Roller{MaxTime: defaultRotateTime, Rotation: afterRotation}
 	}()
 	errorPraseArgs := "size=100 age=10 keep=10 compress=1"
 	roller, err := ParseRoller(errorPraseArgs)
@@ -109,7 +109,7 @@ func TestInitDefaultRoller(t *testing.T) {
 	InitGlobalRoller("time=1")
 	defer func() {
 		// reset
-		defaultRoller = Roller{MaxTime: defaultRotateTime}
+		defaultRoller = Roller{MaxTime: defaultRotateTime, Rotation: afterRotation}
 	}()
 	if lg.roller.MaxTime != 60*60 {
 		t.Errorf("expected roller reset, but not, got: %d", lg.roller.MaxTime)


### PR DESCRIPTION
Now the log rotate function not configurable, may be should support user define own rotate function.

In our platform a script will find the file with format mosn_2020-xx-xx:14:00:00.log and will delete them period. So i need own rotate function to rename the file with our format.