### PR TITLE
add log file name format configure

### DIFF
--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -336,7 +336,7 @@ func TestRotateWithFormat(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	logName := "/tmp/mosn_bench/printdefaultroller.log"
+	logName := "/tmp/mosn_bench/TestRotateWithFormat.log"
 	rollerName := "/tmp/mosn_bench/" + "mosn-" + time.Now().Format("2006-01-02_15") + ".log"
 	os.Remove(logName)
 	os.Remove(rollerName)

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -375,3 +375,49 @@ func TestRotateWithFormat(t *testing.T) {
 	}
 
 }
+
+func TestRotateWithFormatLocalFile(t *testing.T) {
+	err := InitGlobalRoller("format=2006-01-02_15-mosn.log")
+	if err != nil {
+		t.Fatal(err)
+	}
+	logName := "TestRotateWithFormat.log"
+	rollerName := time.Now().Format("2006-01-02_15") + "-mosn" + ".log"
+	os.Remove(logName)
+	os.Remove(rollerName)
+	// replace rotate interval for test
+	doRotate = testRotate
+	defer func() {
+		doRotate = doRotateFunc
+	}()
+	defaultRoller.MaxTime = 10
+	logger, err := GetOrCreateLogger(logName, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// 1111 will be rotated to rollerName
+	logger.Print(buffer.NewIoBufferString("1111111"), false)
+	time.Sleep(11 * time.Second)
+	// 2222 will be writed in logName
+	logger.Print(buffer.NewIoBufferString("2222222"), false)
+	time.Sleep(1 * time.Second)
+	logger.Close() // stop the rotate
+
+	lines, err := readLines(logName)
+	if err != nil {
+		t.Fatalf("read %s error: %v", logName, err)
+	}
+	if len(lines) != 1 || lines[0] != "2222222" {
+		t.Fatalf("read %s data: %v, not expected", logName, lines)
+	}
+
+	lines, err = readLines(rollerName)
+	if err != nil {
+		t.Fatalf("read %s error: %v", rollerName, err)
+	}
+	if len(lines) != 1 || lines[0] != "1111111" {
+		t.Fatalf("read %s data: %v, not expected", rollerName, lines)
+	}
+	os.Remove(logName)
+	os.Remove(rollerName)
+}

--- a/log/roller_test.go
+++ b/log/roller_test.go
@@ -38,6 +38,12 @@ func TestParseRoller(t *testing.T) {
 		t.Errorf("ParseRoller should be failed")
 	}
 
+	errorPraseArgs = "format=2006_01_02_15_logName.log"
+	roller, err = ParseRoller(errorPraseArgs)
+	if err != nil {
+		t.Errorf("ParseRoller failed")
+	}
+
 	errorPraseArgs = "size=100, age=10, keep=10, compress=off"
 	roller, err = ParseRoller(errorPraseArgs)
 	if err == nil {
@@ -105,6 +111,9 @@ func TestInitDefaultRoller(t *testing.T) {
 	}
 	if lg.roller.MaxTime != defaultRotateTime {
 		t.Errorf("unexpected default roller, got %d", lg.roller.MaxTime)
+	}
+	if lg.outputPath != "/tmp/" {
+		t.Errorf("unexpected outputPath, got %+v", lg.outputPath)
 	}
 	InitGlobalRoller("time=1")
 	defer func() {


### PR DESCRIPTION
add log name format configure in global_log_roller.

eg : User can configure the log name with "format=mosn-2006-01-02_15.log" 

![image](https://user-images.githubusercontent.com/11661906/91993125-937bcd00-ed67-11ea-8c8e-a2b8628cc147.png)
