### PR TITLE
enhance logger rotator

### DIFF
--- a/log/errorlog.go
+++ b/log/errorlog.go
@@ -17,9 +17,7 @@
 
 package log
 
-import (
-	"mosn.io/pkg/utils"
-)
+import "mosn.io/pkg/utils"
 
 var DefaultLogger ErrorLogger
 

--- a/log/logger.go
+++ b/log/logger.go
@@ -371,7 +371,7 @@ func (l *Logger) Fatalln(args ...interface{}) {
 	os.Exit(1)
 }
 
-func (l *Logger) calcInterval(now time.Time) time.Duration {
+func (l *Logger) calculateInterval(now time.Time) time.Duration {
 	// caculate the next time need to rotate
 	_, localOffset := now.Zone()
 	return time.Duration(l.roller.MaxTime-(now.Unix()+int64(localOffset))%l.roller.MaxTime) * time.Second
@@ -389,7 +389,7 @@ func (l *Logger) startRotate() {
 		if now.Sub(l.create) > time.Duration(l.roller.MaxTime)*time.Second {
 			interval = 0
 		} else {
-			interval = l.calcInterval(now)
+			interval = l.calculateInterval(now)
 		}
 		doRotate(l, interval)
 	}, func(r interface{}) {
@@ -413,7 +413,7 @@ func doRotateFunc(l *Logger, interval time.Duration) {
 				}
 			}
 			now := time.Now()
-			interval = l.calcInterval(now)
+			interval = l.calculateInterval(now)
 		case <-timer.C:
 			now := time.Now()
 			info := LoggerInfo{FileName: l.output, CreateTime: l.create}
@@ -422,8 +422,8 @@ func doRotateFunc(l *Logger, interval time.Duration) {
 			l.create = now
 			go l.Reopen()
 
-			if interval == 0 { // recaculate interval
-				interval = l.calcInterval(now)
+			if interval == 0 { // recalculate interval
+				interval = l.calculateInterval(now)
 			} else {
 				interval = time.Duration(l.roller.MaxTime) * time.Second
 			}

--- a/log/logger.go
+++ b/log/logger.go
@@ -35,8 +35,6 @@ import (
 )
 
 var (
-	// localOffset is offset in seconds east of UTC
-	_, localOffset = time.Now().Zone()
 	// error
 	ErrReopenUnsupported = errors.New("reopen unsupported")
 
@@ -72,6 +70,7 @@ type Logger struct {
 	// implementation elements
 	create          time.Time
 	once            sync.Once
+	rollerUpdate    chan bool
 	stopRotate      chan struct{}
 	reopenChan      chan struct{}
 	closeChan       chan struct{}
@@ -133,8 +132,11 @@ func GetOrCreateLogger(output string, roller *Roller) (*Logger, error) {
 		return lg.(*Logger), nil
 	}
 
+	notify := make(chan bool, 1)
 	if roller == nil {
 		roller = &defaultRoller
+		// use defaultRoller, add a notify
+		registeNofify(notify)
 	}
 
 	if roller.Handler == nil {
@@ -148,6 +150,7 @@ func GetOrCreateLogger(output string, roller *Roller) (*Logger, error) {
 		reopenChan:      make(chan struct{}),
 		closeChan:       make(chan struct{}),
 		stopRotate:      make(chan struct{}),
+		rollerUpdate:    notify,
 		// writer and create will be setted in start()
 	}
 	err := lg.start()
@@ -368,6 +371,12 @@ func (l *Logger) Fatalln(args ...interface{}) {
 	os.Exit(1)
 }
 
+func (l *Logger) calcInterval(now time.Time) time.Duration {
+	// caculate the next time need to rotate
+	_, localOffset := now.Zone()
+	return time.Duration(l.roller.MaxTime-(now.Unix()+int64(localOffset))%l.roller.MaxTime) * time.Second
+}
+
 func (l *Logger) startRotate() {
 	utils.GoWithRecover(func() {
 		// roller not by time
@@ -380,8 +389,7 @@ func (l *Logger) startRotate() {
 		if now.Sub(l.create) > time.Duration(l.roller.MaxTime)*time.Second {
 			interval = 0
 		} else {
-			// caculate the next time need to rotate
-			interval = time.Duration(l.roller.MaxTime-(now.Unix()+int64(localOffset))%l.roller.MaxTime) * time.Second
+			interval = l.calcInterval(now)
 		}
 		doRotate(l, interval)
 	}, func(r interface{}) {
@@ -393,10 +401,15 @@ var doRotate func(l *Logger, interval time.Duration) = doRotateFunc
 
 func doRotateFunc(l *Logger, interval time.Duration) {
 	for {
+		timer := time.NewTimer(interval)
 		select {
 		case <-l.stopRotate:
 			return
-		case <-time.After(interval):
+		case <-l.rollerUpdate:
+			timer.Stop()
+			now := time.Now()
+			interval = l.calcInterval(now)
+		case <-timer.C:
 			now := time.Now()
 			info := LoggerInfo{FileName: l.output, CreateTime: l.create}
 			info.LogRoller = *l.roller
@@ -405,7 +418,7 @@ func doRotateFunc(l *Logger, interval time.Duration) {
 			go l.Reopen()
 
 			if interval == 0 { // recaculate interval
-				interval = time.Duration(l.roller.MaxTime-(now.Unix()+int64(localOffset))%l.roller.MaxTime) * time.Second
+				interval = l.calcInterval(now)
 			} else {
 				interval = time.Duration(l.roller.MaxTime) * time.Second
 			}

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -330,3 +330,24 @@ func TestRotateRightNow(t *testing.T) {
 		t.Fatalf("log rotate is not expected")
 	}
 }
+
+func TestDynamicLocalOffset(t *testing.T) {
+	l := &Logger{
+		roller: &Roller{
+			MaxTime: int64(24 * 60 * 60),
+		},
+	}
+	// simulate a location
+	loc, _ := time.LoadLocation("America/Los_Angeles")
+	today, _ := time.ParseInLocation("2006-01-02 15:04:05 -0700 MST", "2020-11-01 00:00:00 -0700 PDT", loc)
+	for i := 0; i < 3; i++ {
+		interval := l.calcInterval(today)
+		tomorrow := today.Add(interval)
+		// rotate
+		today = tomorrow
+	}
+	ts := today.Format("2006-01-02 15:04:05")
+	if ts != "2020-11-03 00:00:00" {
+		t.Fatalf("time rotate not expected: %v", today)
+	}
+}

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -341,7 +341,7 @@ func TestDynamicLocalOffset(t *testing.T) {
 	loc, _ := time.LoadLocation("America/Los_Angeles")
 	today, _ := time.ParseInLocation("2006-01-02 15:04:05 -0700 MST", "2020-11-01 00:00:00 -0700 PDT", loc)
 	for i := 0; i < 3; i++ {
-		interval := l.calcInterval(today)
+		interval := l.calculateInterval(today)
 		tomorrow := today.Add(interval)
 		// rotate
 		today = tomorrow

--- a/log/roller_test.go
+++ b/log/roller_test.go
@@ -134,7 +134,8 @@ func TestRollerHandler(t *testing.T) {
 	}
 	linfo := &LoggerInfo{
 		LogRoller: Roller{
-			MaxTime: defaultRotateTime,
+			MaxTime:    defaultRotateTime,
+			MaxBackups: 10,
 		},
 		FileName:   name,
 		CreateTime: time.Now(),

--- a/utils/goroutine.go
+++ b/utils/goroutine.go
@@ -19,28 +19,32 @@ package utils
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"runtime/debug"
 )
 
-var debugIgnoreStdout = false
+var recoverLogger func(w io.Writer, r interface{}) = defaultRecoverLogger
+
+func RegisterRecoverLogger(f func(w io.Writer, r interface{})) {
+	recoverLogger = f
+}
+
+func defaultRecoverLogger(w io.Writer, r interface{}) {
+	fmt.Fprintf(w, "%s goroutine panic: %v\n%s\n", CacheTime(), r, string(debug.Stack()))
+}
 
 // GoWithRecover wraps a `go func()` with recover()
 func GoWithRecover(handler func(), recoverHandler func(r interface{})) {
 	go func() {
 		defer func() {
 			if r := recover(); r != nil {
-				// TODO: log
-				if !debugIgnoreStdout {
-					fmt.Fprintf(os.Stderr, "%s goroutine panic: %v\n%s\n", CacheTime(), r, string(debug.Stack()))
-				}
+				recoverLogger(os.Stderr, r)
 				if recoverHandler != nil {
 					go func() {
 						defer func() {
 							if p := recover(); p != nil {
-								if !debugIgnoreStdout {
-									fmt.Fprintf(os.Stderr, "recover goroutine panic:%v\n%s\n", p, string(debug.Stack()))
-								}
+								recoverLogger(os.Stderr, p)
 							}
 						}()
 						recoverHandler(r)

--- a/utils/goroutine.go
+++ b/utils/goroutine.go
@@ -26,6 +26,9 @@ import (
 
 var recoverLogger func(w io.Writer, r interface{}) = defaultRecoverLogger
 
+// RegisterRecoverLogger replace the log handler when go with recover catch a panic
+// notice the replaced handler should be simple.
+// if the handler panic, the recover handler will be failed.
 func RegisterRecoverLogger(f func(w io.Writer, r interface{})) {
 	recoverLogger = f
 }

--- a/utils/goroutine_test.go
+++ b/utils/goroutine_test.go
@@ -19,12 +19,21 @@ package utils
 
 import (
 	"fmt"
+	"io"
+	"os"
 	"testing"
 	"time"
 )
 
+func debugIgnoreLogger(w io.Writer, r interface{}) {
+}
+
+func TestMain(m *testing.M) {
+	RegisterRecoverLogger(debugIgnoreLogger)
+	os.Exit(m.Run())
+}
+
 func TestGoWithRecover(t *testing.T) {
-	debugIgnoreStdout = true
 	panicStr := "test panic"
 	panicHandler := func() {
 		panic(panicStr)
@@ -42,7 +51,6 @@ func TestGoWithRecover(t *testing.T) {
 
 // recover handler panic, should not panic
 func TestRecoverPanic(t *testing.T) {
-	debugIgnoreStdout = true
 	handler := func() {
 		panic("1")
 	}
@@ -73,7 +81,6 @@ func (r *_run) exec() {
 }
 
 func TestGoWithRecoverAgain(t *testing.T) {
-	debugIgnoreStdout = true
 	r := &_run{}
 	r.work()
 	time.Sleep(time.Second)


### PR DESCRIPTION
1. get time zone every rotate time
2. check file exists before rotate, if exists, add a generation suffix
3. recalcuate rotate interval when default global roller updated by config
4. support recover  logger registered if needed.