### PR TITLE
Mosn windows support - alpha version

### DIFF
--- a/utils/dup.go
+++ b/utils/dup.go
@@ -1,9 +1,0 @@
-// +build !arm64
-
-package utils
-
-import "syscall"
-
-func Dup(from, to int) error {
-	return syscall.Dup2(from, to)
-}

--- a/utils/dup_arm64.go
+++ b/utils/dup_arm64.go
@@ -1,9 +1,0 @@
-package utils
-
-import "syscall"
-
-// if oldd ≠ newd and flags == 0, the behavior is identical to dup2(oldd, newd).
-// arm support dup3 only
-func Dup(from, to int) error {
-	return syscall.Dup3(from, to, 0)
-}

--- a/utils/dup_linux_arm64.go
+++ b/utils/dup_linux_arm64.go
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import "syscall"
+
+// if oldd ≠ newd and flags == 0, the behavior is identical to dup2(oldd, newd).
+// arm support dup3 only
+func Dup(from, to int) error {
+	return syscall.Dup3(from, to, 0)
+}

--- a/utils/dup_unix.go
+++ b/utils/dup_unix.go
@@ -1,0 +1,26 @@
+// +build darwin linux
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ package utils
+
+import "syscall"
+
+func Dup(from, to int) error {
+	return syscall.Dup2(from, to)
+}

--- a/utils/dup_windows.go
+++ b/utils/dup_windows.go
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ package utils
+
+import (
+    "syscall"
+)
+
+var (
+    procSetStdHandle = syscall.MustLoadDLL("kernel32.dll").MustFindProc("SetStdHandle").Addr()
+)
+
+func Dup(from, to int) error {
+	r0, _, e1 := syscall.Syscall(procSetStdHandle, 2, uintptr(from), uintptr(to), 0)
+    if r0 == 0 {
+        if e1 != 0 {
+            return error(e1)
+        }
+        return syscall.EINVAL
+	}
+    return nil
+}

--- a/utils/syscall.go
+++ b/utils/syscall.go
@@ -19,14 +19,7 @@ package utils
 
 import (
 	"os"
-	"syscall"
 	"time"
-)
-
-var (
-	// keep the standard for recover
-	standardStdoutFd, _ = syscall.Dup(int(os.Stdout.Fd()))
-	standardStderrFd, _ = syscall.Dup(int(os.Stderr.Fd()))
 )
 
 // SetHijackStdPipeline hijacks stdout and stderr outputs into the file path

--- a/utils/syscall_unix.go
+++ b/utils/syscall_unix.go
@@ -1,0 +1,31 @@
+// +build darwin linux
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ package utils
+
+import (
+	"os"
+	"syscall"
+)
+
+var (
+	// keep the standard for recover
+	standardStdoutFd, _ = syscall.Dup(int(os.Stdout.Fd()))
+	standardStderrFd, _ = syscall.Dup(int(os.Stderr.Fd()))
+)

--- a/utils/syscall_windows.go
+++ b/utils/syscall_windows.go
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ package utils
+
+import (
+	"os"
+)
+
+var (
+	// keep the standard for recover
+	standardStdoutFd = int(os.Stdout.Fd())
+	standardStderrFd = int(os.Stderr.Fd())
+)


### PR DESCRIPTION
As Envoy announced alpha support for windows. Mosn should also move forward to support windows.
This PR is for mosn pkg repository, there will be another PR for mosn.