### PR TITLE
fix dup, support linux/x86 linux/arm64 darwin/x86 only

### DIFF
--- a/utils/dup.go
+++ b/utils/dup.go
@@ -1,9 +1,13 @@
-// +build !arm64
+// +build linux,!arm64,!amd64,!386 darwin,!amd64,!386 windows
 
 package utils
 
-import "syscall"
+import (
+	"fmt"
+	"runtime"
+)
 
 func Dup(from, to int) error {
-	return syscall.Dup2(from, to)
+	fmt.Printf("GOOS %s, GOARCH %s is not support dup\n", runtime.GOOS, runtime.GOARCH)
+	return nil
 }

--- a/utils/dup_386.go
+++ b/utils/dup_386.go
@@ -1,0 +1,9 @@
+// +build linux darwin
+
+package utils
+
+import "syscall"
+
+func Dup(from, to int) error {
+	return syscall.Dup2(from, to)
+}

--- a/utils/dup_amd64.go
+++ b/utils/dup_amd64.go
@@ -1,0 +1,9 @@
+// +build linux darwin
+
+package utils
+
+import "syscall"
+
+func Dup(from, to int) error {
+	return syscall.Dup2(from, to)
+}

--- a/utils/dup_arm64.go
+++ b/utils/dup_arm64.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package utils
 
 import "syscall"

--- a/utils/syscall.go
+++ b/utils/syscall.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/utils/syscall_test.go
+++ b/utils/syscall_test.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/utils/syscall_windows.go
+++ b/utils/syscall_windows.go
@@ -1,0 +1,30 @@
+// +build windows
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import "fmt"
+
+// SetHijackStdPipeline hijacks stdout and stderr outputs into the file path
+func SetHijackStdPipeline(filepath string, stdout, stderr bool) {
+	fmt.Println("windows not not support SetHijackStdPipeline")
+}
+
+func ResetHjiackStdPipeline() {
+}


### PR DESCRIPTION
### 支持DUP方法生效的 编译条件
GOOS=linux GOARCH=amd64 / 386 / arm64
GOOS=darwin GOARCH= amd64 / 386 
### 其他可以编译通过，但是不生效的条件
GOOS=windows
GOOS=darwin GOARCH= arm64