### PR TITLE
fix: fix GetLogWriter Concurrency issues

### DIFF
--- a/log/roller.go
+++ b/log/roller.go
@@ -38,7 +38,7 @@ var (
 	// lumberjacks maps log filenames to the logger
 	// that is being used to keep them rolled/maintained.
 	lumberjacks       = make(map[string]*lumberjack.Logger)
-	lumberjacksLocker sync.RWMutex
+	lumberjacksLocker sync.Mutex
 
 	errInvalidRollerParameter = errors.New("invalid roller parameter")
 )
@@ -91,18 +91,6 @@ func (l Roller) GetLogWriter() io.Writer {
 		absPath = l.Filename // oh well, hopefully they're consistent in how they specify the filename
 	}
 
-	// try get logger
-	lumberjacksLocker.RLock()
-	lj, has := lumberjacks[absPath]
-	lumberjacksLocker.RUnlock()
-	if has {
-		return lj
-	}
-	// get slow logger
-	return l.getSlowLogWriter(absPath)
-}
-
-func (l Roller) getSlowLogWriter(absPath string) io.Writer {
 	lumberjacksLocker.Lock()
 	defer lumberjacksLocker.Unlock()
 	lj, has := lumberjacks[absPath]

--- a/log/roller.go
+++ b/log/roller.go
@@ -78,11 +78,9 @@ type Roller struct {
 type RollerHandler func(l *LoggerInfo)
 
 // GetLogWriter returns an io.Writer that writes to a rolling logger.
-// This should be called only from the main goroutine (like during
-// server setup) because this method is not thread-safe; it is careful
-// to create only one log writer per log file, even if the log file
-// is shared by different sites or middlewares. This ensures that
-// rolling is synchronized, since a process (or multiple processes)
+// it is careful to create only one log writer per log file, even if
+// the log file is shared by different sites or middlewares. This ensures
+// that rolling is synchronized, since a process (or multiple processes)
 // should not create more than one roller on the same file at the
 // same time. See issue #1363.
 func (l Roller) GetLogWriter() io.Writer {

--- a/log/roller_test.go
+++ b/log/roller_test.go
@@ -25,6 +25,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestParseRoller(t *testing.T) {
@@ -165,4 +167,12 @@ func TestRollerHandler(t *testing.T) {
 			t.Fatalf("file %s read data %s, expected %s", fname, string(b), expected)
 		}
 	}
+}
+
+func TestRollerGetLogWriter(t *testing.T) {
+	roller := defaultRoller
+	roller.Filename = "test"
+	io1 := roller.GetLogWriter()
+	io2 := roller.GetLogWriter()
+	assert.Equal(t, io1, io2)
 }


### PR DESCRIPTION
多个goroute 同时调用 Roller.GetLogWriter 函数，由于 map 并发不安全 导致panic。