### PR TITLE
feature: added the new SyncList type that have the VisitSafe method.

### DIFF
--- a/utils/sync_list.go
+++ b/utils/sync_list.go
@@ -90,14 +90,10 @@ func (l *SyncList) VisitSafe(f func(v interface{})) {
 	}
 }
 
-// Len returns the length of the list l.
+// Len returns the number of elements of list l.
 func (l *SyncList) Len() int {
 	l.mux.Lock()
 	defer l.mux.Unlock()
 
-	n := 0
-	for e := l.list.Front(); e != nil; e = e.Next() {
-		n++
-	}
-	return n
+	return l.list.Len()
 }

--- a/utils/sync_list.go
+++ b/utils/sync_list.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 )
 
+// SyncList similar with the builtin List container while it is concurrency safe.
 type SyncList struct {
 	list     *list.List
 	curr     *list.Element
@@ -29,18 +30,26 @@ type SyncList struct {
 	visitMux sync.Mutex
 }
 
+// NewSyncList returns an initialized SyncList.
 func NewSyncList() *SyncList {
 	return &SyncList{
-		list: list.New(),
+		list:     list.New(),
+		curr:     nil,
+		mux:      sync.Mutex{},
+		visitMux: sync.Mutex{},
 	}
 }
 
+// PushBack inserts a new element e with value v at the back of list l and returns e.
 func (l *SyncList) PushBack(v interface{}) *list.Element {
 	l.mux.Lock()
 	defer l.mux.Unlock()
 	return l.list.PushBack(v)
 }
 
+// Remove removes e from l if e is an element of list l.
+// It returns the element value e.Value.
+// The element must not be nil.
 func (l *SyncList) Remove(e *list.Element) interface{} {
 	l.mux.Lock()
 	defer l.mux.Unlock()
@@ -76,10 +85,12 @@ func (l *SyncList) VisitSafe(f func(v interface{})) {
 		if curr == nil {
 			break
 		}
+
 		f(curr.Value)
 	}
 }
 
+// Len returns the length of the list l.
 func (l *SyncList) Len() int {
 	l.mux.Lock()
 	defer l.mux.Unlock()

--- a/utils/sync_list.go
+++ b/utils/sync_list.go
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import (
+	"container/list"
+	"sync"
+)
+
+type SyncList struct {
+	list     *list.List
+	curr     *list.Element
+	mux      sync.Mutex
+	visitMux sync.Mutex
+}
+
+func NewSyncList() *SyncList {
+	return &SyncList{
+		list: list.New(),
+	}
+}
+
+func (l *SyncList) PushBack(v interface{}) *list.Element {
+	l.mux.Lock()
+	defer l.mux.Unlock()
+	return l.list.PushBack(v)
+}
+
+func (l *SyncList) Remove(e *list.Element) interface{} {
+	l.mux.Lock()
+	defer l.mux.Unlock()
+	if e == l.curr {
+		l.curr = l.curr.Prev()
+	}
+
+	return l.list.Remove(e)
+}
+
+// VisitSafe means the visit function f can visit each element safely even f may block some time.
+// Also, it won't block other operations(e.g. Remove) when the visit function f is blocked.
+// But, it can not run parallel since there is an instance level curr point.
+func (l *SyncList) VisitSafe(f func(v interface{})) {
+	l.visitMux.Lock()
+	defer l.visitMux.Unlock()
+
+	// just in case there is some dirty data left from the previous call.
+	l.mux.Lock()
+	l.curr = nil
+	l.mux.Unlock()
+
+	for {
+		l.mux.Lock()
+		if l.curr == nil {
+			l.curr = l.list.Front()
+		} else {
+			l.curr = l.curr.Next()
+		}
+		curr := l.curr
+		l.mux.Unlock()
+
+		if curr == nil {
+			break
+		}
+		f(curr.Value)
+	}
+}
+
+func (l *SyncList) Len() int {
+	l.mux.Lock()
+	defer l.mux.Unlock()
+
+	n := 0
+	for e := l.list.Front(); e != nil; e = e.Next() {
+		n++
+	}
+	return n
+}

--- a/utils/sync_list_test.go
+++ b/utils/sync_list_test.go
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestSyncListPushBack(t *testing.T) {
+	l := NewSyncList()
+
+	wg := sync.WaitGroup{}
+	wg.Add(100)
+	for i := 0; i < 100; i++ {
+		go func() {
+			defer wg.Done()
+			l.PushBack(1)
+		}()
+	}
+	wg.Wait()
+	len := l.Len()
+	if len != 100 {
+		t.Errorf("sync list length expect 100 while got: %v", len)
+	}
+}
+
+func BenchmarkSyncListPushBack(b *testing.B) {
+	l := NewSyncList()
+	for i := 0; i < b.N; i++ {
+		l.PushBack(1)
+	}
+}
+
+func TestSyncListRemove(t *testing.T) {
+	l := NewSyncList()
+	wg := sync.WaitGroup{}
+	wg.Add(200)
+	for i := 0; i < 100; i++ {
+		go func() {
+			defer wg.Done()
+			l.PushBack(1)
+		}()
+		go func() {
+			defer wg.Done()
+			e := l.PushBack(2)
+			l.Remove(e)
+		}()
+	}
+	wg.Wait()
+	len := l.Len()
+	if len != 100 {
+		t.Errorf("sync list length expect 100 while got: %v", len)
+	}
+}
+
+func BenchmarkSyncListRemove(b *testing.B) {
+	l := NewSyncList()
+	for i := 0; i < b.N; i++ {
+		e := l.PushBack(1)
+		l.Remove(e)
+	}
+}
+
+func TestSyncListVisitSafe(t *testing.T) {
+	l := NewSyncList()
+	for i := 0; i < 100; i++ {
+		l.PushBack(i)
+	}
+	count := 0
+	l.VisitSafe(func(_ interface{}) {
+		count++
+	})
+	if count != 100 {
+		t.Errorf("count expected 100 while got: %v", count)
+	}
+	len := l.Len()
+	if len != 100 {
+		t.Errorf("sync list length expect 100 while got: %v", len)
+	}
+}
+
+func TestSyncListVisitSafeWithRemove(t *testing.T) {
+	l := NewSyncList()
+	for i := 0; i < 100; i++ {
+		l.PushBack(i)
+	}
+	count := 0
+	l.VisitSafe(func(v interface{}) {
+		n := v.(int)
+		first := l.list.Front().Value.(int)
+
+		if n != first {
+			t.Errorf("visit value not match the first value, %v vs %v", n, first)
+		}
+		l.Remove(l.list.Front().Next())
+		l.Remove(l.list.Front())
+
+		count++
+	})
+	if count != 50 {
+		t.Errorf("count expected 50 while got: %v", count)
+	}
+	len := l.Len()
+	if len != 0 {
+		t.Errorf("sync list length expect 0 while got: %v", len)
+	}
+}
+
+func BenchmarkSyncListVisitSafe(b *testing.B) {
+	l := NewSyncList()
+	for i := 0; i < 100; i++ {
+		l.PushBack(i)
+	}
+	for i := 0; i < b.N; i++ {
+		l.VisitSafe(func(v interface{}) {
+			n := v.(int)
+			n++
+		})
+	}
+}

--- a/utils/sync_list_test.go
+++ b/utils/sync_list_test.go
@@ -134,3 +134,26 @@ func BenchmarkSyncListVisitSafe(b *testing.B) {
 		})
 	}
 }
+
+func TestSyncListVisitSafeWithPushBack(t *testing.T) {
+	l := NewSyncList()
+	for i := 0; i < 100; i++ {
+		l.PushBack(i)
+	}
+	count := 0
+	l.VisitSafe(func(v interface{}) {
+		n := v.(int)
+		if n%2 == 0 && n > 10 {
+			l.PushBack(n / 2)
+		}
+
+		count++
+	})
+	if count != 171 {
+		t.Errorf("count expected 50 while got: %v", count)
+	}
+	len := l.Len()
+	if len != count {
+		t.Errorf("sync list length expect %v while got: %v", count, len)
+	}
+}


### PR DESCRIPTION
VisitSafe means the visit function f can visit each element safely even f may block some time.
Also, it won't block other operations(e.g. Remove) when the visit function f is blocked.
But, it can not run parallel since there is an instance-level curr point.

https://github.com/mosn/mosn/pull/1922 depends on this PR.