### PR TITLE
support iobuffer pool error write to log

### DIFF
--- a/buffer/iobuffer_pool.go
+++ b/buffer/iobuffer_pool.go
@@ -81,5 +81,9 @@ func NewIoBuffer(size int) IoBuffer {
 
 // PutIoBuffer is a a wrapper for ibPool
 func PutIoBuffer(buf IoBuffer) error {
-	return ibPool.PutIoBuffer(buf)
+	err := ibPool.PutIoBuffer(buf)
+	if err != nil {
+		logFunc(err.Error())
+	}
+	return err
 }

--- a/buffer/log.go
+++ b/buffer/log.go
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package buffer
+
+import (
+	"fmt"
+	"os"
+)
+
+// LogFunc record buffer's error log, default to std error.
+// User can be overwrite it with any log implementation function
+// For example, use mosn.io/pkg/log logger.Errorf overwrite it.
+var logFunc = func(msg string) {
+	fmt.Fprintf(os.Stderr, msg)
+}
+
+func SetLogFunc(f func(msg string)) {
+	logFunc = f
+}

--- a/buffer/log.go
+++ b/buffer/log.go
@@ -22,13 +22,14 @@ import (
 	"os"
 )
 
-// LogFunc record buffer's error log, default to std error.
+// logFunc record buffer's error log, default to std error.
 // User can be overwrite it with any log implementation function
 // For example, use mosn.io/pkg/log logger.Errorf overwrite it.
 var logFunc = func(msg string) {
-	fmt.Fprintf(os.Stderr, msg)
+	fmt.Fprintf(os.Stderr, "%s", msg)
 }
 
+// SetLogFunc use f overwrite logFunc.
 func SetLogFunc(f func(msg string)) {
 	logFunc = f
 }


### PR DESCRIPTION
支持一个可扩展的函数记录错误信息。在MOSN中可以使用log.DefaultLogger等封装来写入日志，不直接引用log是因为log本身依赖buffer，会形成循环依赖。
测试Example

```Go
package main

import (
        "mosn.io/pkg/log"
        "mosn.io/pkg/buffer"
)

func main() {

        buffer.SetLogFunc(func(msg string) {
                log.DefaultLogger.Errorf("[iobuffer] %s", msg)
        })  

        buf := buffer.GetIoBuffer(0)
        buf.Write([]byte("1234"))

        buffer.PutIoBuffer(buf)
        buffer.PutIoBuffer(buf)
}
```
输出结果
```bash
2022-03-30 17:37:25,126 [ERROR] [iobuffer] PutIoBuffer duplicate
```

