### PR TITLE
Adds a build matrix for supported Go versions

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: ${{ matrix.go-version }}
           cache: true
 
       - name: Run Unit tests.

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -19,6 +19,29 @@ jobs:
   test:
     name: test
     runs-on: ubuntu-latest
+    # A matrix proves the supported range of Go versions work. This must always
+    # include the floor Go version policy of Mosn and the current Go version.
+    # Mosn's floor Go version for libraries is two behind current, e.g. if Go
+    # supports 1.19 and 1.20, Mosn libraries must work on 1.18, 1.19 and 1.20.
+    #
+    # A floor version is required to ensure Mosn can receive security patches.
+    # Without one, dependencies become locked to an old version of Go, which
+    # itself receives no security patch updates.
+    #
+    # Mosn's binary is built with Go's floor version, e.g. if Go supports 1.19
+    # and 1.20, Mosn will build any downloadable executables with 1.19.
+    #
+    # Even if mosn works with a Go version below its supported floor, users
+    # must not depend on this. Mosn and its library dependencies are free to
+    # use features in the supported floor Go version at any time. This remains
+    # true even if mosn library dependencies are not eagerly updated.
+    strategy:
+      matrix:
+        go-version:
+          - "1.19"  # Current Go version
+          - "1.18"
+          - "1.17"  # Floor Go version of Mosn == current - 2
+
     steps:
       - name: Check out code
         uses: actions/checkout@v3

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module mosn.io/pkg
 
-go 1.18
+go 1.17
 
 require (
 	github.com/dubbogo/getty v1.3.4

--- a/go.sum
+++ b/go.sum
@@ -427,6 +427,7 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1
 github.com/tmc/grpc-websocket-proxy v0.0.0-20200427203606-3cfed13b9966/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/toolkits/concurrent v0.0.0-20150624120057-a4371d70e3e3/go.mod h1:QDlpd3qS71vYtakd2hmdpqhJ9nwv6mD6A30bQ1BPBFE=
+github.com/ugorji/go v1.1.7 h1:/68gy2h+1mWMrwZFeD1kQialdSzAb432dtpeJ42ovdo=
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=
 github.com/ugorji/go/codec v1.1.7 h1:2SvQaVZ1ouYrrKKwoSk2pzd4A9evlKJb9oTL+OaLUSs=
 github.com/ugorji/go/codec v1.1.7/go.mod h1:Ax+UKWsSmolVDwsd+7N3ZtXu+yMGCf907BLYF3GoBXY=


### PR DESCRIPTION
This also lowers go.mod to 1.17 accordingly

cc @taoyuanyuan @antJack

See mosn/mosn#2153