### PR TITLE
[bugfix]: default global roller will panic if time not set

### DIFF
--- a/log/roller.go
+++ b/log/roller.go
@@ -139,6 +139,7 @@ func DefaultRoller() *Roller {
 		MaxSize:    defaultRotateSize,
 		MaxAge:     defaultRotateAge,
 		MaxBackups: defaultRotateKeep,
+		MaxTime:    defaultRotateTime,
 		Compress:   false,
 		LocalTime:  true,
 		Handler:    rollerHandler,


### PR DESCRIPTION
When roller.Time not configured, logger will panic with
```
goroutine panic: runtime error: integer divide by zero
```

In mosn.io/pkg/log/logger.go:371
```
return time.Duration(l.roller.MaxTime-(now.Unix()+int64(localOffset))%l.roller.MaxTime) * time.Second
```