### PR TITLE
bugfix: global roller maxtime update from default value to 0 will panic

### DIFF
--- a/log/logger.go
+++ b/log/logger.go
@@ -406,8 +406,15 @@ func doRotateFunc(l *Logger, interval time.Duration) {
 				default:
 				}
 			}
-			now := time.Now()
-			interval = l.calculateInterval(now)
+
+			if defaultRoller.MaxTime > 0 {
+				now := time.Now()
+				interval = l.calculateInterval(now)
+			} else {
+				l.roller.Filename = l.output
+				l.writer = l.roller.GetLogWriter()
+				return
+			}
 		case <-timer.C:
 			now := time.Now()
 			info := LoggerInfo{FileName: l.output, CreateTime: l.create}

--- a/log/roller.go
+++ b/log/roller.go
@@ -139,7 +139,6 @@ func DefaultRoller() *Roller {
 		MaxSize:    defaultRotateSize,
 		MaxAge:     defaultRotateAge,
 		MaxBackups: defaultRotateKeep,
-		MaxTime:    defaultRotateTime,
 		Compress:   false,
 		LocalTime:  true,
 		Handler:    rollerHandler,

--- a/log/roller_test.go
+++ b/log/roller_test.go
@@ -176,3 +176,12 @@ func TestRollerGetLogWriter(t *testing.T) {
 	io2 := roller.GetLogWriter()
 	assert.Equal(t, io1, io2)
 }
+
+func TestGlobalRollerUpdate(t *testing.T) {
+	logger, _ := GetOrCreateLogger("/tmp/testlog.txt", nil)
+	time.Sleep(time.Second)
+	InitGlobalRoller("age=7 size=500 compress=on")
+	assert.Equal(t, true, logger.roller.Compress)
+	assert.Equal(t, 500, logger.roller.MaxSize)
+	assert.Equal(t, 7, logger.roller.MaxAge)
+}


### PR DESCRIPTION
```	
        logger, _ := GetOrCreateLogger("/tmp/testlog.txt", nil)
	time.Sleep(time.Second)
	InitGlobalRoller("age=7 size=500 compress=on")
```
Codes will panic at:
```
case <-l.rollerUpdate:
			if !timer.Stop() {
				select {
				case <-timer.C:
				default:
				}
			}

			now := time.Now()
			interval = l.calculateInterval(now)

...
_, localOffset := now.Zone()
	return time.Duration(l.roller.MaxTime-(now.Unix()+int64(localOffset))%l.roller.MaxTime) * time.Second
```